### PR TITLE
Changed date in spec to string to match controller specs

### DIFF
--- a/spec/controllers/models/landmark_spec.rb
+++ b/spec/controllers/models/landmark_spec.rb
@@ -4,7 +4,7 @@ describe "Landmark" do
   before do 
     @figure = Figure.create(:name => "Fiorello LaGuardia") 
 
-    @airport =  Landmark.create(:name => "LG Airport", :year_completed => 1950) 
+    @airport =  Landmark.create(:name => "LG Airport", :year_completed => "1950") 
     @library = Landmark.create(:name => "Library")
     
   end
@@ -12,7 +12,7 @@ describe "Landmark" do
 
   it "has a name and a year_completed" do 
     expect(@airport.name).to eq("LG Airport")
-    expect(@airport.year_completed).to eq(1950)
+    expect(@airport.year_completed).to eq("1950")
   end
 
   it "belongs to a figure" do 


### PR DESCRIPTION
Controller tests expect `year_completed` to be a `String`. Model test expected `Fixnum`. Changed model test to expect `String`.
