### PR TITLE
explicitly require application_controller first

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -8,5 +8,7 @@ ActiveRecord::Base.establish_connection(
   :database => "db/nyc#{ENV['SINATRA_ENV']}.sqlite"
 )
 
+require_relative "../app/controllers/application_controller.rb"
+
 Dir[File.join(File.dirname(__FILE__), "../app/models", "*.rb")].each {|f| require f}
 Dir[File.join(File.dirname(__FILE__), "../app/controllers", "*.rb")].sort.each {|f| require f}


### PR DESCRIPTION
Hope I'm doing this the right way here.
@pletcher 
A better fix to #33 (accounting for a controller with a name that would cause it to be loaded before the application_controller)
