### PR TITLE
Add db/schema.rb to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
-Gemfile.lock
+db/schema.rb


### PR DESCRIPTION
1b92340 removed this file, but it's generated
after migrations and can affect git. Squelch that.