### PR TITLE
Updates to move /figures/new test to figures_controller

### DIFF
--- a/spec/figures_controller_view_spec.rb
+++ b/spec/figures_controller_view_spec.rb
@@ -74,6 +74,18 @@ describe FiguresController do
     expect(figure.landmarks).to include(landmark)
   end
 
+  it "creates checkboxes for all the landmarks and titles created on the Figures new page" do
+    Landmark.create(name: 'BQE', year_completed: 1961)
+      visit "/figures/new"
+      expect(page).to have_css("input[type=\"checkbox\"]")
+      expect(page).to have_content('BQE')
+      Title.create(:name => "Mayor")
+      visit "/figures/new"
+      expect(page).to have_css("input[type=\"checkbox\"]")
+      expect(page).to have_content('Mayor')
+
+  end
+
   it "allows you to list all figures" do
     visit '/figures'
 

--- a/spec/landmarks_controller_view_spec.rb
+++ b/spec/landmarks_controller_view_spec.rb
@@ -74,16 +74,4 @@ describe LandmarksController do
     expect(@updated_landmark.name).to eq("BQE!!!!")
     expect(@updated_landmark.year_completed.to_s).to eq("9999")
   end
-
-  it "creates checkboxes for all the landmarks and titles created on the Figures new page" do
-    Landmark.create(name: 'BQE', year_completed: 1961)
-      visit "/figures/new"
-      expect(page).to have_css("input[type=\"checkbox\"]")
-      expect(page).to have_content('BQE')
-      Title.create(:name => "Mayor")
-      visit "/figures/new"
-      expect(page).to have_css("input[type=\"checkbox\"]")
-      expect(page).to have_content('Mayor')
-
-  end
 end


### PR DESCRIPTION
Since this test, checks the `/figures/new` page to be updating with the new Landmark and the new title, I believe the test would better fit here since you are actually checking the view of the Figures and in the LandmarksController test, haven't even built out logic to handle the figure.

The impact shouldn't be more than the flow being more cohesive, Landmark information stays with strictly landmarks and the Figures information stays with figures.